### PR TITLE
fix: remove die($t) from set() method in Time class

### DIFF
--- a/src/Lib/Helper/Time.php
+++ b/src/Lib/Helper/Time.php
@@ -13,7 +13,6 @@ class Time
      */
     static public function set(ZKTeco $self, $t)
     {
-      die($t);
         $self->_section = __METHOD__;
 
         $command = Util::CMD_SET_TIME;


### PR DESCRIPTION
`setTime()` method was not working because of `die($t)`.
So I removed that.