### PR TITLE
Fix reverseHex method for inputs with an odd number of digits

### DIFF
--- a/src/Lib/Helper/Util.php
+++ b/src/Lib/Helper/Util.php
@@ -140,6 +140,11 @@ class Util
   {
     $tmp = '';
 
+    // Reversing algorithm needs an even number of digits to work, so we add a leading 0 if needed
+    if (\strlen($hex) % 2 !== 0) {
+      $hex = '0' . $hex;
+    }
+
     for ($i = strlen($hex); $i >= 0; $i--) {
       $tmp .= substr($hex, $i, 2);
       $i--;


### PR DESCRIPTION
Util::reverseHex does not behave correctly when the input has an odd number of digits

```php
echo Rats\Zkteco\Lib\Helper\Util::reverseHex('13E7'); // Outputs "E713", OK
echo Rats\Zkteco\Lib\Helper\Util::reverseHex('3E7'); // Outputs "E7", KO, should output E703
```
This can happen in real world usage when creating / updating the card ID of an user. The result is an incorrect card ID in the device.

This fix corrects this behavior by adding a leading zero so the input always has an even number of digits.